### PR TITLE
Add frontend dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.21 as builder
+
+# Set CGO_ENABLED to 0 to avoid linking with C libraries
+# this is required to run the binary in a scratch container
+ENV CGO_ENABLED=0
+
+RUN mkdir /build
+WORKDIR /build
+COPY . .
+RUN go mod download \
+    && go mod verify \
+    && go build -o app
+
+FROM scratch as runner
+COPY --from=builder /build/app /app
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
Closes #3 

We had to set environment variable `CGO_ENABLED=0` in order to disable linking with clib in order to run on scratch.
https://www.reddit.com/r/golang/comments/18dinxm/comment/kchfu13/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button